### PR TITLE
Add channel status metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,42 @@ To run it:
 | mirth_messages_sent_total  | How many messages have been sent | channel |
 | mirth_messages_errored_total  | How many messages have errored | channel |
 
+```
+# HELP mirth_channel_status 
+# TYPE mirth_channel_status gauge
+mirth_channel_status{channel="foo", status="STARTED"} 1
+mirth_channel_status{channel="bar", status="PAUSED"} 1
+
+# HELP mirth_messages_errored_total How many messages have errored (per channel).
+# TYPE mirth_messages_errored_total gauge
+mirth_messages_errored_total{channel="foo"} 0
+mirth_messages_errored_total{channel="bar"} 2
+
+# HELP mirth_messages_filtered_total How many messages have been filtered (per channel).
+# TYPE mirth_messages_filtered_total gauge
+mirth_messages_filtered_total{channel="foo"} 0
+mirth_messages_filtered_total{channel="bar"} 193
+
+# HELP mirth_messages_queued How many messages are currently queued (per channel).
+# TYPE mirth_messages_queued gauge
+mirth_messages_queued{channel="foo"} 0
+mirth_messages_queued{channel="bar"} 0
+
+# HELP mirth_messages_received_total How many messages have been received (per channel).
+# TYPE mirth_messages_received_total gauge
+mirth_messages_received_total{channel="foo"} 6.3965406e+07
+mirth_messages_received_total{channel="bar"} 387
+
+# HELP mirth_messages_sent_total How many messages have been sent (per channel).
+# TYPE mirth_messages_sent_total gauge
+mirth_messages_sent_total{channel="foo"} 1.21855264e+08
+mirth_messages_sent_total{channel="bar"} 964
+
+# HELP mirth_up Was the last Mirth query successful.
+# TYPE mirth_up gauge
+mirth_up 1
+```
+
 ## Flags
     ./mirth_channel_exporter --help
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
 Export [Mirth Connect](https://en.wikipedia.org/wiki/Mirth_Connect) channel
 statistics to [Prometheus](https://prometheus.io).
 
-Metrics are retrieved using the Mirth Connect REST API. This has only been tested
-with Mirth Connect 3.7.1, and it should work with version after 3.7.1.
+Metrics are retrieved using the Mirth Connect REST API. This was tested in versions 3.7.1 and newer. It is generally expected to work in any MC release 3.4.0 and greater but has not been explicitly tested in all releases. Test cases are welcome.
 
 To run it:
 
@@ -15,6 +14,8 @@ To run it:
 | Metric | Description | Labels |
 | ------ | ------- | ------ |
 | mirth_up | Was the last Mirth CLI query successful | |
+| mirth_request_duration | Histogram for the runtime of the metric pull from Mirth | |
+| mirth_channel_status | Status of all deployed channels | channel, status |
 | mirth_messages_received_total | How many messages have been received | channel |
 | mirth_messages_filtered_total  | How many messages have been filtered | channel |
 | mirth_messages_queued | How many messages are currently queued | channel |
@@ -22,10 +23,19 @@ To run it:
 | mirth_messages_errored_total  | How many messages have errored | channel |
 
 ```
-# HELP mirth_channel_status 
+# HELP mirth_channel_status
 # TYPE mirth_channel_status gauge
 mirth_channel_status{channel="foo", status="STARTED"} 1
 mirth_channel_status{channel="bar", status="PAUSED"} 1
+
+# HELP mirth_request_duration Histogram for the runtime of the metric pull from Mirth.
+# TYPE mirth_request_duration histogram
+mirth_request_duration_bucket{le="0.1"} 0
+mirth_request_duration_bucket{le="0.2"} 0
+mirth_request_duration_bucket{le="0.30000000000000004"} 1
+...
+mirth_request_duration_bucket{le="2.0000000000000004"} 5
+mirth_request_duration_bucket{le="+Inf"} 5
 
 # HELP mirth_messages_errored_total How many messages have errored (per channel).
 # TYPE mirth_messages_errored_total gauge

--- a/main.go
+++ b/main.go
@@ -202,7 +202,7 @@ func (e *Exporter) AssembleMetrics(channelStatusMap *ChannelStatusMap, ch chan<-
 
 	for _, channel := range channelStatusMap.Channels {
 		ch <- prometheus.MustNewConstMetric(
-			channelStatuses, prometheus.UntypedValue, 1, channel.Name, channel.State,
+			channelStatuses, prometheus.GaugeValue, 1, channel.Name, channel.State,
 		)
 
 		for _, entry := range channel.CurrentStatistics {

--- a/main.go
+++ b/main.go
@@ -24,12 +24,8 @@ type ChannelStatus struct {
 	State              string                         `xml:"state"`
 	CurrentStatistics  []ChannelStatusStatisticsEntry `xml:"statistics>entry"`
 	LifetimeStatistics []ChannelStatusStatisticsEntry `xml:"lifetimeStatistics>entry"`
-}
 
-type ChannelStatusStatistics struct {
-	Entries []ChannelStatusStatisticsEntry `xml:"entry"`
 	/*
-		The stats returned from status API
 		   <statistics class="linked-hash-map">
 			  <entry>
 				<com.mirth.connect.donkey.model.message.Status>RECEIVED</com.mirth.connect.donkey.model.message.Status>

--- a/main.go
+++ b/main.go
@@ -209,7 +209,7 @@ func (e *Exporter) AssembleMetrics(channelStatusMap *ChannelStatusMap, ch chan<-
 			metric := pickMetric(entry.Status)
 			if metric != nil {
 				ch <- prometheus.MustNewConstMetric(
-					metric, prometheus.CounterValue, entry.MessageCount, channel.Name,
+					metric, prometheus.GaugeValue, entry.MessageCount, channel.Name,
 				)
 			}
 		}

--- a/main.go
+++ b/main.go
@@ -1,222 +1,21 @@
 package main
 
 import (
-	"crypto/tls"
-	"encoding/xml"
 	"flag"
 	"github.com/joho/godotenv"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
 )
 
-type ChannelStatusMap struct {
-	XMLName  xml.Name        `xml:"list"`
-	Channels []ChannelStatus `xml:"dashboardStatus"`
-}
-type ChannelStatus struct {
-	XMLName            xml.Name                       `xml:"dashboardStatus"`
-	ChannelId          string                         `xml:"channelId"`
-	Name               string                         `xml:"name"`
-	State              string                         `xml:"state"`
-	CurrentStatistics  []ChannelStatusStatisticsEntry `xml:"statistics>entry"`
-	LifetimeStatistics []ChannelStatusStatisticsEntry `xml:"lifetimeStatistics>entry"`
-
-	/*
-		<statistics class="linked-hash-map">
-		  <entry>
-			<com.mirth.connect.donkey.model.message.Status>RECEIVED</com.mirth.connect.donkey.model.message.Status>
-			<long>70681</long>
-		  </entry>
-		  <entry>
-			<com.mirth.connect.donkey.model.message.Status>FILTERED</com.mirth.connect.donkey.model.message.Status>
-			<long>0</long>
-		  </entry>
-		  <entry>
-			<com.mirth.connect.donkey.model.message.Status>SENT</com.mirth.connect.donkey.model.message.Status>
-			<long>67139</long>
-		  </entry>
-		  <entry>
-			<com.mirth.connect.donkey.model.message.Status>ERROR</com.mirth.connect.donkey.model.message.Status>
-			<long>3542</long>
-		  </entry>
-		</statistics>
-	*/
-}
-
-type ChannelStatusStatisticsEntry struct {
-	Status       string  `xml:"com.mirth.connect.donkey.model.message.Status"`
-	MessageCount float64 `xml:"long"`
-}
-
-const namespace = "mirth"
-const channelStatusesApi = "/api/channels/statuses"
-
 var (
-	tr = &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-	}
-	client = &http.Client{Transport: tr}
-
 	listenAddress = flag.String("web.listen-address", ":9141",
 		"Address to listen on for telemetry")
 	metricsPath = flag.String("web.telemetry-path", "/metrics",
 		"Path under which to expose metrics")
-
-	// Metrics
-	up = prometheus.NewDesc(
-		prometheus.BuildFQName(namespace, "", "up"),
-		"Was the last Mirth query successful.",
-		nil, nil,
-	)
-	channelStatuses = prometheus.NewDesc(
-		prometheus.BuildFQName(namespace, "", "channel_status"),
-		"Status of all deployed channels",
-		[]string{"channel", "status"}, nil,
-	)
-	messagesReceived = prometheus.NewDesc(
-		prometheus.BuildFQName(namespace, "", "messages_received_total"),
-		"How many messages have been received (per channel).",
-		[]string{"channel"}, nil,
-	)
-	messagesFiltered = prometheus.NewDesc(
-		prometheus.BuildFQName(namespace, "", "messages_filtered_total"),
-		"How many messages have been filtered (per channel).",
-		[]string{"channel"}, nil,
-	)
-	messagesQueued = prometheus.NewDesc(
-		prometheus.BuildFQName(namespace, "", "messages_queued"),
-		"How many messages are currently queued (per channel).",
-		[]string{"channel"}, nil,
-	)
-	messagesSent = prometheus.NewDesc(
-		prometheus.BuildFQName(namespace, "", "messages_sent_total"),
-		"How many messages have been sent (per channel).",
-		[]string{"channel"}, nil,
-	)
-	messagesErrored = prometheus.NewDesc(
-		prometheus.BuildFQName(namespace, "", "messages_errored_total"),
-		"How many messages have errored (per channel).",
-		[]string{"channel"}, nil,
-	)
-	requestDuration = prometheus.NewHistogram(prometheus.HistogramOpts{
-		Name:    prometheus.BuildFQName(namespace, "", "request_duration"),
-		Help:    "Histogram for the runtime of the metric pull from Mirth.",
-		Buckets: prometheus.LinearBuckets(0.1, 0.1, 20),
-	})
 )
-
-type Exporter struct {
-	mirthEndpoint, mirthUsername, mirthPassword string
-}
-
-func NewExporter(mirthEndpoint string, mirthUsername string, mirthPassword string) *Exporter {
-	return &Exporter{
-		mirthEndpoint: mirthEndpoint,
-		mirthUsername: mirthUsername,
-		mirthPassword: mirthPassword,
-	}
-}
-
-func (e *Exporter) Describe(ch chan<- *prometheus.Desc) {
-	ch <- up
-	ch <- channelStatuses
-	ch <- messagesReceived
-	ch <- messagesFiltered
-	ch <- messagesQueued
-	ch <- messagesSent
-	ch <- messagesErrored
-}
-
-func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
-	channelIdStatusMap, err := e.LoadChannelStatuses()
-	if err != nil {
-		ch <- prometheus.MustNewConstMetric(
-			up, prometheus.GaugeValue, 0,
-		)
-		log.Println(err)
-		return
-	}
-	ch <- prometheus.MustNewConstMetric(
-		up, prometheus.GaugeValue, 1,
-	)
-
-	e.AssembleMetrics(channelIdStatusMap, ch)
-}
-
-func (e *Exporter) LoadChannelStatuses() (*ChannelStatusMap, error) {
-	timer := prometheus.NewTimer(requestDuration)
-	defer timer.ObserveDuration()
-	req, err := http.NewRequest("GET", e.mirthEndpoint+channelStatusesApi, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	// This one line implements the authentication required for the task.
-	req.SetBasicAuth(e.mirthUsername, e.mirthPassword)
-	// Make request and show output.
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-
-	body, err := ioutil.ReadAll(resp.Body)
-	resp.Body.Close()
-	if err != nil {
-		return nil, err
-	}
-	// fmt.Println(string(body))
-
-	// initialize map variable
-	var channelStatusMap ChannelStatusMap
-	// unmarshal body byteArray into the ChannelStatusMap struct
-	err = xml.Unmarshal(body, &channelStatusMap)
-	if err != nil {
-		return nil, err
-	}
-
-	return &channelStatusMap, nil
-}
-
-func pickMetric(status string) *prometheus.Desc {
-	switch status {
-	case "RECEIVED":
-		return messagesReceived
-	case "FILTERED":
-		return messagesFiltered
-	case "SENT":
-		return messagesSent
-	case "QUEUED":
-		return messagesQueued
-	case "ERROR":
-		return messagesErrored
-	}
-	return nil
-}
-
-func (e *Exporter) AssembleMetrics(channelStatusMap *ChannelStatusMap, ch chan<- prometheus.Metric) {
-	ch <- requestDuration
-
-	for _, channel := range channelStatusMap.Channels {
-		ch <- prometheus.MustNewConstMetric(
-			channelStatuses, prometheus.GaugeValue, 1, channel.Name, channel.State,
-		)
-
-		for _, entry := range channel.CurrentStatistics {
-			metric := pickMetric(entry.Status)
-			if metric != nil {
-				ch <- prometheus.MustNewConstMetric(
-					metric, prometheus.GaugeValue, entry.MessageCount, channel.Name,
-				)
-			}
-		}
-	}
-
-	log.Println("Endpoint scraped")
-}
 
 func main() {
 	err := godotenv.Load()
@@ -230,8 +29,9 @@ func main() {
 	mirthUsername := os.Getenv("MIRTH_USERNAME")
 	mirthPassword := os.Getenv("MIRTH_PASSWORD")
 
-	exporter := NewExporter(mirthEndpoint, mirthUsername, mirthPassword)
-	prometheus.MustRegister(exporter)
+	prometheus.MustRegister(
+		NewExporter(mirthEndpoint, mirthUsername, mirthPassword),
+	)
 
 	http.Handle(*metricsPath, promhttp.Handler())
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {

--- a/metrics.go
+++ b/metrics.go
@@ -1,0 +1,178 @@
+package main
+
+import (
+	"crypto/tls"
+	"encoding/xml"
+	"github.com/prometheus/client_golang/prometheus"
+	"io/ioutil"
+	"log"
+	"net/http"
+)
+
+const namespace = "mirth"
+const channelStatusesApi = "/api/channels/statuses"
+
+var (
+	tr = &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+
+	client = &http.Client{Transport: tr}
+
+	up = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "", "up"),
+		"Was the last Mirth query successful.",
+		nil, nil,
+	)
+
+	channelStatuses = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "", "channel_status"),
+		"Status of all deployed channels",
+		[]string{"channel", "status"}, nil,
+	)
+
+	messagesReceived = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "", "messages_received_total"),
+		"How many messages have been received (per channel).",
+		[]string{"channel"}, nil,
+	)
+
+	messagesFiltered = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "", "messages_filtered_total"),
+		"How many messages have been filtered (per channel).",
+		[]string{"channel"}, nil,
+	)
+
+	messagesQueued = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "", "messages_queued"),
+		"How many messages are currently queued (per channel).",
+		[]string{"channel"}, nil,
+	)
+
+	messagesSent = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "", "messages_sent_total"),
+		"How many messages have been sent (per channel).",
+		[]string{"channel"}, nil,
+	)
+
+	messagesErrored = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "", "messages_errored_total"),
+		"How many messages have errored (per channel).",
+		[]string{"channel"}, nil,
+	)
+
+	requestDuration = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name:    prometheus.BuildFQName(namespace, "", "request_duration"),
+		Help:    "Histogram for the runtime of the metric pull from Mirth.",
+		Buckets: prometheus.LinearBuckets(0.1, 0.1, 20),
+	})
+)
+
+func (e *Exporter) LoadChannelStatuses() (*ChannelStatusMap, error) {
+	timer := prometheus.NewTimer(requestDuration)
+	defer timer.ObserveDuration()
+	req, err := http.NewRequest("GET", e.mirthEndpoint+channelStatusesApi, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// This one line implements the authentication required for the task.
+	req.SetBasicAuth(e.mirthUsername, e.mirthPassword)
+	// Make request and show output.
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+	// fmt.Println(string(body))
+
+	// initialize map variable
+	var channelStatusMap ChannelStatusMap
+	// unmarshal body byteArray into the ChannelStatusMap struct
+	err = xml.Unmarshal(body, &channelStatusMap)
+	if err != nil {
+		return nil, err
+	}
+
+	return &channelStatusMap, nil
+}
+
+func pickMetric(status string) *prometheus.Desc {
+	switch status {
+	case "RECEIVED":
+		return messagesReceived
+	case "FILTERED":
+		return messagesFiltered
+	case "SENT":
+		return messagesSent
+	case "QUEUED":
+		return messagesQueued
+	case "ERROR":
+		return messagesErrored
+	}
+	return nil
+}
+
+func (e *Exporter) AssembleMetrics(channelStatusMap *ChannelStatusMap, ch chan<- prometheus.Metric) {
+	ch <- requestDuration
+
+	for _, channel := range channelStatusMap.Channels {
+		ch <- prometheus.MustNewConstMetric(
+			channelStatuses, prometheus.GaugeValue, 1, channel.Name, channel.State,
+		)
+
+		for _, entry := range channel.CurrentStatistics {
+			metric := pickMetric(entry.Status)
+			if metric != nil {
+				ch <- prometheus.MustNewConstMetric(
+					metric, prometheus.GaugeValue, entry.MessageCount, channel.Name,
+				)
+			}
+		}
+	}
+
+	log.Println("Endpoint scraped")
+}
+
+type Exporter struct {
+	mirthEndpoint, mirthUsername, mirthPassword string
+}
+
+func NewExporter(mirthEndpoint string, mirthUsername string, mirthPassword string) *Exporter {
+	return &Exporter{
+		mirthEndpoint: mirthEndpoint,
+		mirthUsername: mirthUsername,
+		mirthPassword: mirthPassword,
+	}
+}
+
+func (e *Exporter) Describe(ch chan<- *prometheus.Desc) {
+	ch <- up
+	ch <- channelStatuses
+	ch <- messagesReceived
+	ch <- messagesFiltered
+	ch <- messagesQueued
+	ch <- messagesSent
+	ch <- messagesErrored
+}
+
+func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
+	channelIdStatusMap, err := e.LoadChannelStatuses()
+	if err != nil {
+		ch <- prometheus.MustNewConstMetric(
+			up, prometheus.GaugeValue, 0,
+		)
+		log.Println(err)
+		return
+	}
+	ch <- prometheus.MustNewConstMetric(
+		up, prometheus.GaugeValue, 1,
+	)
+
+	e.AssembleMetrics(channelIdStatusMap, ch)
+}

--- a/types.go
+++ b/types.go
@@ -1,0 +1,44 @@
+package main
+
+import "encoding/xml"
+
+type ChannelStatus struct {
+	XMLName            xml.Name                       `xml:"dashboardStatus"`
+	ChannelId          string                         `xml:"channelId"`
+	Name               string                         `xml:"name"`
+	State              string                         `xml:"state"`
+	CurrentStatistics  []ChannelStatusStatisticsEntry `xml:"statistics>entry"`
+	LifetimeStatistics []ChannelStatusStatisticsEntry `xml:"lifetimeStatistics>entry"`
+
+	/*
+		<statistics class="linked-hash-map">
+		  <entry>
+			<com.mirth.connect.donkey.model.message.Status>RECEIVED</com.mirth.connect.donkey.model.message.Status>
+			<long>70681</long>
+		  </entry>
+		  <entry>
+			<com.mirth.connect.donkey.model.message.Status>FILTERED</com.mirth.connect.donkey.model.message.Status>
+			<long>0</long>
+		  </entry>
+		  <entry>
+			<com.mirth.connect.donkey.model.message.Status>SENT</com.mirth.connect.donkey.model.message.Status>
+			<long>67139</long>
+		  </entry>
+		  <entry>
+			<com.mirth.connect.donkey.model.message.Status>ERROR</com.mirth.connect.donkey.model.message.Status>
+			<long>3542</long>
+		  </entry>
+		</statistics>
+	*/
+}
+
+type ChannelStatusMap struct {
+	XMLName  xml.Name        `xml:"list"`
+	Channels []ChannelStatus `xml:"dashboardStatus"`
+}
+
+type ChannelStatusStatisticsEntry struct {
+	Status       string  `xml:"com.mirth.connect.donkey.model.message.Status"`
+	MessageCount float64 `xml:"long"`
+}
+


### PR DESCRIPTION
* Add a metric for channel status (whether each deployed channel is started vs stopped vs paused etc.)
* Add a histogram metric for the time to fetch data for Mirth API
* Instead of pulling statistics from `/api/channels/statistics` and channel names from `/api/channels/idsAndNames`, pull all of the data from `/api/channels/statuses`.

TODO:
* [x] Update readme (table and sample metrics)
* [x] ? Bump minimum supported version